### PR TITLE
Added virtual destructor

### DIFF
--- a/dynamic-polymorphism-c-cpp/virtualtables.cpp
+++ b/dynamic-polymorphism-c-cpp/virtualtables.cpp
@@ -8,6 +8,8 @@ class Unary_Function {
   public:
     // constructor
     Unary_Function(int lb, int ub) : lower_bound(lb), upper_bound(ub) {};
+    // virtual destructor
+    virtual ~Unary_Function() {}
     // pure virtual function
     virtual double value_at(double x) = 0;
     // virtual function


### PR DESCRIPTION
**Error:**

The error in the `virtualtables.cpp` file is that the base class `Unary_Function` does not have a virtual destructor.

**Fix:**

To fix this issue, we need to add a virtual destructor to the `Unary_Function` class.

Corrected Code:

```c
#include <stdio.h>
#include <stdlib.h>

class Unary_Function {
  private:
    int lower_bound;
    int upper_bound;
  public:
    // constructor
    Unary_Function(int lb, int ub) : lower_bound(lb), upper_bound(ub) {};
    // virtual destructor
    virtual ~Unary_Function() {}
    // pure virtual function
    virtual double value_at(double x) = 0;
    // virtual function
    virtual double negative_value_at(double x) {
      return -value_at(x);
    }
    // non-virtual function
    void tabulate() {
      for(int x = lower_bound; x <= upper_bound; x++) {
        printf("f(%d)=%lf\n", x, value_at(x));
      }
    };
    // static function
    static bool same_functions_for_ints(Unary_Function *f1, Unary_Function *f2, double tolerance) {
      if(f1->lower_bound != f2->lower_bound) return false;
      if(f1->upper_bound != f2->upper_bound) return false;
      for(int x = f1->lower_bound; x <= f1->upper_bound; x++) {
        double delta = f1->value_at(x) - f2->value_at(x);
        if(delta < 0) delta = -delta;
        if(delta > tolerance) return false;
      }
      return true;
    };
};

class Square : public Unary_Function {
  public:
    Square(int lb, int ub) : Unary_Function(lb, ub) {};
    virtual double value_at(double x) {
      return x*x;
    };
};

class Linear : public Unary_Function {
  private:
    double a;
    double b;
  public:
    Linear(int lb, int ub, double a_coef, double b_coef) : Unary_Function(lb, ub), a(a_coef), b(b_coef) {};
    virtual double value_at(double x) {
      return a*x + b;
    };
};

int main() {
  Unary_Function *f1 = new Square(-2, 2);
  f1->tabulate();
  Unary_Function *f2 = new Linear(-2, 2, 5, -2);
  f2->tabulate();
  printf("f1==f2: %s\n", Unary_Function::same_functions_for_ints(f1, f2, 1E-6) ? "DA" : "NE");
  printf("neg_val f2(1) = %lf\n", f2->negative_value_at(1.0));
  delete f1;
  delete f2;
  return 0;
}
```

**Short Description of the Fix:**

The error occurred because the base class `Unary_Function` is inherited by other classes (`Square` and `Linear`) but lacks a virtual destructor. This can lead to undefined behavior when deleting derived class objects through a pointer to the base class. Adding a virtual destructor ensures that the destructors of derived classes are properly called when objects are deleted via a base class pointer.

**Testing:**

After adding the virtual destructor to `Unary_Function`, the code should compile without errors related to missing virtual destructors. This change ensures correct deletion of objects through base class pointers, maintaining proper object cleanup in polymorphic scenarios.